### PR TITLE
partial and total auth duration logging

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -329,8 +329,11 @@ auth_log(struct ssh *ssh, int authenticated, int partial,
 
 	if (authctxt->postponed)
 		authmsg = "Postponed";
-	else if (partial)
+	else if (partial) {
 		authmsg = "Partial";
+		// Update partial auth timestamp
+		slog_set_last_partial_auth_time();
+	}
 	else
 		authmsg = authenticated ? "Accepted" : "Failed";
 

--- a/slog.h
+++ b/slog.h
@@ -33,6 +33,9 @@ void	slog_set_principal(const char *);
 void	slog_set_user(const char *);
 void	slog_set_auth_info(const char *);
 void	slog_set_client_version(const char *);
+void	slog_set_auth_start(void);
+void	slog_set_auth_end(void);
+void	slog_set_last_partial_auth_time(void);
 
 // loggers
 void	slog_exit_handler(void);

--- a/sshd.c
+++ b/sshd.c
@@ -2100,6 +2100,9 @@ main(int ac, char **av)
 	authctxt = xcalloc(1, sizeof(*authctxt));
 	ssh->authctxt = authctxt;
 
+	// Set auth start timestamp
+	slog_set_auth_start();
+
 	authctxt->loginmsg = loginmsg;
 
 	/* XXX global for cleanup, access from other modules */
@@ -2140,6 +2143,10 @@ main(int ac, char **av)
 	}
 
  authenticated:
+
+	// Set auth end timestamp
+	slog_set_auth_end();
+
 	/*
 	 * Cancel the alarm we set to limit the time taken for
 	 * authentication.

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1744,6 +1744,9 @@ The
 argument accepts one or more of the following keys
 .Pp
 .Bl -tag -width Ds -compact -offset indent
+.It Cm auth_duration
+The authentication stage duration in seconds (double floating-point).
+.sp
 .It Cm auth_info
 Additional information about the authentication method (e.g. kerberos principal
 or certificate fingerprint).
@@ -1766,6 +1769,10 @@ The duration of the session in seconds (end_time - start_time)
 .sp
 .It Cm end_time
 Seconds since the epoch that the session was closed
+.sp
+.It Cm last_partial_auth_duration
+The time taken to reach the start of the last authentication factor stage in
+seconds (double floating-point).
 .sp
 .It Cm method
 The authentication method used to open the session.


### PR DESCRIPTION
Summary:
Two authentication durations are logged:

`auth_duration` represents the total authentication time, including any time spent waiting for Duo or other required auth factors.

`last_partial_auth_duration` represents the time taken to reach the start of the last authentication factor stage (at Facebook, this is the Duo stage). This is useful because we don't really want/need to time the user's reaction time to the Duo prompt, we care more about the earlier auth stages that we can control.

Differential Revision: D20084340

