### PR TITLE
Don't use the pam stack for password auth if Kerberos auth being used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,3 +26,5 @@ and the user is authenticated by the certificate.
 config file.
 
 - Fix a bug where some options in `Match` clauses are not correctly `none`able.
+
+- Prevent password authentication with PAM if Kerberos authentication is used.

--- a/auth-passwd.c
+++ b/auth-passwd.c
@@ -112,7 +112,7 @@ auth_password(struct ssh *ssh, const char *password)
 	}
 #endif
 #ifdef USE_PAM
-	if (options.use_pam)
+	if (options.use_pam && options.kerberos_authentication != 1)
 		return (sshpam_auth_passwd(authctxt, password) && ok);
 #endif
 #if defined(USE_SHADOW) && defined(HAS_SHADOW_EXPIRE)


### PR DESCRIPTION
Summary:
This change prevents the following scenario
 - Password login to devserver with local account e.g. siteops
 - Siteops not found in kerberos DB, so falls back to PAM
 - Duo is down and fails open
 - Authentication succeeds without the password ever being tested

With this change, the logic falls through to the end of auth_password where local
authentication happens.

Things that don't solve this problem:

`KerberosOrLocalPasswd=no` this causes `auth_krb5_password` to return 0 and bypass
all local password checks.

Using `ExposeAuthInfo=yes` and doing conditional logic in PAM.  The auth info is
not set until after auth section of PAM has completed.

Differential Revision: D20803559

